### PR TITLE
Add descriptive error message to update-jekyll-history if no arg given

### DIFF
--- a/bin/update-jekyll-history
+++ b/bin/update-jekyll-history
@@ -2,7 +2,7 @@
 
 set -e
 
-[[ $# -eq 0 ]] && exit 1
+[[ $# -eq 0 ]] && echo "Specify the PR number" && exit 1
 
 PULL=$1
 git add History.markdown


### PR DESCRIPTION
Maybe it's just me, but I've always found quiet quits kind of unhelpful. This adds an error message for you just in case you are drinking heavily or something and merging PRs. It's a thing.
